### PR TITLE
Added getSource(), fixed _getMasterStatus(), Constants cleanup

### DIFF
--- a/minidsp.js
+++ b/minidsp.js
@@ -71,7 +71,7 @@ program
 	.description('Set input source [analog|toslink|usb]')
 	.action((source) => {
 		let dsp = device();
-		actions.push(dsp.setInput(source));
+		actions.push(dsp.setSource(source));
 	});
 
 program

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,9 +3,17 @@ const constants = {
 	USB_VID: 0x2752,
 	USB_PID: 0x0011,
 
-	INPUT_ANALOG: 0,
-	INPUT_TOSLINK: 1,
-	INPUT_USB: 2
+	SOURCE_INDEX: {
+		'analog': 0,
+		'toslink': 1,
+		'usb': 2
+	},
+
+	SOURCE_NAME: {
+		0: 'analog',
+		1: 'toslink',
+		2: 'usb'
+	}
 };
 
 module.exports = constants;


### PR DESCRIPTION
Many things in this PR, if you want me to split them up let me know.

1. Fixed bugs in _getMasterStatus().  According to the Air app, it seems that the actual volume is -0.5 * the volume returned from the buffer.  There was also an issue with the buffer slice causing it to always throw errors.
2. Renamed setInput() to setSource() and updated throughout.  This is confusing when you have an "Input" class, and when getInput is related to that class instead of the selected source.  I would also recommend changing the command to switch source from "minidsp input X" to "minidsp source X" to match, but I made sure the changes were backwards compatible with this command.
3. Added getInput().  Returns the current input as a string.  Very straightforward.
4. Updated constants.js to be more useful.  There is now Constants.SOURCE_INDEX[string], which, when given "analog", "toslink", etc. returns the associated index.  It now also works the other way with Constants.SOURCE_NAME[index], which returns the string associated with an index.  I've updated your code to use these variables.